### PR TITLE
fix deadlock when using blocking wait strategy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>exchange.core2</groupId>
@@ -68,7 +69,7 @@
         <mockito.version>3.3.3</mockito.version>
         <hamcrest.version>1.3</hamcrest.version>
 
-        <delombok.output>delombok</delombok.output>
+        <delombok.output>target/delombok</delombok.output>
     </properties>
 
     <dependencies>
@@ -285,6 +286,7 @@
                             <sourceDirectory>${project.basedir}/src/main/java</sourceDirectory>
                             <outputDirectory>${delombok.output}</outputDirectory>
                             <addOutputDirectory>false</addOutputDirectory>
+                            <encoding>UTF-8</encoding>
                         </configuration>
                         <executions>
                             <execution>
@@ -292,6 +294,49 @@
                                 <goals>
                                     <goal>delombok</goal>
                                 </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <version>1.8</version>
+                        <executions>
+                            <execution>
+                                <id>generate-delomboked-sources-jar</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <jar destfile="${project.build.directory}/${project.build.finalName}-sources.jar"
+                                             basedir="${delombok.output}"/>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <version>3.1.0</version>
+                        <executions>
+                            <execution>
+                                <id>attach-delomboked-sources-jar</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>attach-artifact</goal>
+                                </goals>
+                                <configuration>
+                                    <artifacts>
+                                        <artifact>
+                                            <file>${project.build.directory}/${project.build.finalName}-sources.jar</file>
+                                            <type>jar</type>
+                                            <classifier>sources</classifier>
+                                        </artifact>
+                                    </artifacts>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>
@@ -340,20 +385,6 @@
                             <nexusUrl>https://oss.sonatype.org/</nexusUrl>
                             <autoReleaseAfterClose>true</autoReleaseAfterClose>
                         </configuration>
-                    </plugin>
-
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-source-plugin</artifactId>
-                        <version>3.0.1</version>
-                        <executions>
-                            <execution>
-                                <id>attach-sources</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
                     </plugin>
 
                     <plugin>

--- a/src/main/java/exchange/core2/core/ExchangeApi.java
+++ b/src/main/java/exchange/core2/core/ExchangeApi.java
@@ -35,7 +35,6 @@ import exchange.core2.core.utils.SerializationUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.jpountz.lz4.LZ4Compressor;
-import net.openhft.chronicle.bytes.BytesIn;
 import net.openhft.chronicle.bytes.WriteBytesMarshallable;
 import net.openhft.chronicle.wire.Wire;
 import org.agrona.collections.LongLongConsumer;
@@ -271,10 +270,8 @@ public final class ExchangeApi {
         return submitQueryAsync(
                 query,
                 transferId,
-                cmd -> {
-                    final Stream<BytesIn> sections = OrderBookEventsHelper.deserializeEvents(cmd.matcherEvent).values().stream().map(Wire::bytes);
-                    return query.getResultBuilder().apply(sections);
-                });
+                cmd -> query.createResult(
+                        OrderBookEventsHelper.deserializeEvents(cmd).values().parallelStream().map(Wire::bytes)));
     }
 
     public void publishBinaryData(final ApiBinaryDataCommand apiCmd, final LongConsumer endSeqConsumer) {

--- a/src/main/java/exchange/core2/core/ExchangeCore.java
+++ b/src/main/java/exchange/core2/core/ExchangeCore.java
@@ -88,7 +88,7 @@ public final class ExchangeCore {
                 ringBufferSize,
                 perfCfg.getThreadFactory(),
                 ProducerType.MULTI, // multiple gateway threads are writing
-                perfCfg.getWaitStrategy().getDisruptorWaitStrategy());
+                perfCfg.getWaitStrategy().getDisruptorWaitStrategyFactory().get());
 
         this.api = new ExchangeApi(disruptor.getRingBuffer(), perfCfg.getBinaryCommandsLz4CompressorFactory().get());
 

--- a/src/main/java/exchange/core2/core/common/CoreWaitStrategy.java
+++ b/src/main/java/exchange/core2/core/common/CoreWaitStrategy.java
@@ -22,20 +22,22 @@ import com.lmax.disruptor.YieldingWaitStrategy;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.util.function.Supplier;
+
 @RequiredArgsConstructor
 public enum CoreWaitStrategy {
 
-    BUSY_SPIN(new BusySpinWaitStrategy(), false, false),
+    BUSY_SPIN(BusySpinWaitStrategy::new, false, false),
 
-    YIELDING(new YieldingWaitStrategy(), true, false),
+    YIELDING(YieldingWaitStrategy::new, true, false),
 
-    BLOCKING(new BlockingWaitStrategy(), false, true),
+    BLOCKING(BlockingWaitStrategy::new, false, true),
 
     // special case
     SECOND_STEP_NO_WAIT(null, false, false);
 
     @Getter
-    private final WaitStrategy disruptorWaitStrategy;
+    private final Supplier<WaitStrategy> disruptorWaitStrategyFactory;
 
     @Getter
     private final boolean yield;

--- a/src/main/java/exchange/core2/core/common/api/reports/ReportQuery.java
+++ b/src/main/java/exchange/core2/core/common/api/reports/ReportQuery.java
@@ -21,7 +21,6 @@ import net.openhft.chronicle.bytes.BytesIn;
 import net.openhft.chronicle.bytes.WriteBytesMarshallable;
 
 import java.util.Optional;
-import java.util.function.Function;
 import java.util.stream.Stream;
 
 /**
@@ -39,7 +38,7 @@ public interface ReportQuery<T extends ReportResult> extends WriteBytesMarshalla
     /**
      * @return report map-reduce constructor
      */
-    Function<Stream<BytesIn>, ? extends T> getResultBuilder();
+    T createResult(Stream<BytesIn> sections);
 
     /**
      * Report main logic.

--- a/src/main/java/exchange/core2/core/common/api/reports/SingleUserReportResult.java
+++ b/src/main/java/exchange/core2/core/common/api/reports/SingleUserReportResult.java
@@ -20,10 +20,8 @@ import exchange.core2.core.common.Order;
 import exchange.core2.core.common.PositionDirection;
 import exchange.core2.core.common.UserStatus;
 import exchange.core2.core.utils.SerializationUtils;
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.*;
+import lombok.extern.slf4j.Slf4j;
 import net.openhft.chronicle.bytes.BytesIn;
 import net.openhft.chronicle.bytes.BytesOut;
 import net.openhft.chronicle.bytes.WriteBytesMarshallable;
@@ -36,9 +34,10 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @EqualsAndHashCode
 @Getter
+@Slf4j
 public final class SingleUserReportResult implements ReportResult {
 
     public static SingleUserReportResult IDENTITY = new SingleUserReportResult(0L, null, null, null, null, QueryExecutionStatus.OK);
@@ -89,7 +88,7 @@ public final class SingleUserReportResult implements ReportResult {
     }
 
     @Override
-    public void writeMarshallable(BytesOut bytes) {
+    public void writeMarshallable(final BytesOut bytes) {
 
         bytes.writeLong(uid);
 

--- a/src/main/java/exchange/core2/core/common/api/reports/StateHashReportQuery.java
+++ b/src/main/java/exchange/core2/core/common/api/reports/StateHashReportQuery.java
@@ -17,19 +17,23 @@ package exchange.core2.core.common.api.reports;
 
 import exchange.core2.core.processors.MatchingEngineRouter;
 import exchange.core2.core.processors.RiskEngine;
+import exchange.core2.core.utils.HashingUtils;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
 import net.openhft.chronicle.bytes.BytesIn;
 import net.openhft.chronicle.bytes.BytesOut;
 
 import java.util.Optional;
-import java.util.function.Function;
+import java.util.SortedMap;
+import java.util.TreeMap;
 import java.util.stream.Stream;
 
 @NoArgsConstructor
 @EqualsAndHashCode
 @ToString
+@Slf4j
 public final class StateHashReportQuery implements ReportQuery<StateHashReportResult> {
 
     public StateHashReportQuery(BytesIn bytesIn) {
@@ -42,18 +46,74 @@ public final class StateHashReportQuery implements ReportQuery<StateHashReportRe
     }
 
     @Override
-    public Function<Stream<BytesIn>, StateHashReportResult> getResultBuilder() {
-        return StateHashReportResult::merge;
+    public StateHashReportResult createResult(Stream<BytesIn> sections) {
+        return StateHashReportResult.merge(sections);
     }
 
     @Override
     public Optional<StateHashReportResult> process(MatchingEngineRouter matchingEngine) {
-        return Optional.of(new StateHashReportResult(0, matchingEngine.stateHash()));
+
+        final SortedMap<StateHashReportResult.SubmoduleKey, Integer> hashCodes = new TreeMap<>();
+
+        final int moduleId = matchingEngine.getShardId();
+
+        hashCodes.put(
+                StateHashReportResult.createKey(moduleId, StateHashReportResult.SubmoduleType.MATCHING_BINARY_CMD_PROCESSOR),
+                matchingEngine.getBinaryCommandsProcessor().stateHash());
+
+        hashCodes.put(
+                StateHashReportResult.createKey(moduleId, StateHashReportResult.SubmoduleType.MATCHING_ORDER_BOOKS),
+                HashingUtils.stateHash(matchingEngine.getOrderBooks()));
+
+        hashCodes.put(
+                StateHashReportResult.createKey(moduleId, StateHashReportResult.SubmoduleType.MATCHING_SHARD_MASK),
+                Long.hashCode(matchingEngine.getShardMask()));
+
+        return Optional.of(
+                new StateHashReportResult(hashCodes));
     }
 
     @Override
     public Optional<StateHashReportResult> process(RiskEngine riskEngine) {
-        return Optional.of(new StateHashReportResult(riskEngine.stateHash(), 0));
+
+        final SortedMap<StateHashReportResult.SubmoduleKey, Integer> hashCodes = new TreeMap<>();
+
+        final int moduleId = riskEngine.getShardId();
+
+        hashCodes.put(
+                StateHashReportResult.createKey(moduleId, StateHashReportResult.SubmoduleType.RISK_SYMBOL_SPEC_PROVIDER),
+                riskEngine.getBinaryCommandsProcessor().stateHash());
+
+        hashCodes.put(
+                StateHashReportResult.createKey(moduleId, StateHashReportResult.SubmoduleType.RISK_USER_PROFILE_SERVICE),
+                riskEngine.getUserProfileService().stateHash());
+
+        hashCodes.put(
+                StateHashReportResult.createKey(moduleId, StateHashReportResult.SubmoduleType.RISK_BINARY_CMD_PROCESSOR),
+                riskEngine.getBinaryCommandsProcessor().stateHash());
+
+        hashCodes.put(
+                StateHashReportResult.createKey(moduleId, StateHashReportResult.SubmoduleType.RISK_LAST_PRICE_CACHE),
+                HashingUtils.stateHash(riskEngine.getLastPriceCache()));
+
+        hashCodes.put(
+                StateHashReportResult.createKey(moduleId, StateHashReportResult.SubmoduleType.RISK_FEES),
+                riskEngine.getFees().hashCode());
+
+        hashCodes.put(
+                StateHashReportResult.createKey(moduleId, StateHashReportResult.SubmoduleType.RISK_ADJUSTMENTS),
+                riskEngine.getAdjustments().hashCode());
+
+        hashCodes.put(
+                StateHashReportResult.createKey(moduleId, StateHashReportResult.SubmoduleType.RISK_SUSPENDS),
+                riskEngine.getSuspends().hashCode());
+
+        hashCodes.put(
+                StateHashReportResult.createKey(moduleId, StateHashReportResult.SubmoduleType.RISK_SHARD_MASK),
+                Long.hashCode(riskEngine.getShardMask()));
+
+        return Optional.of(
+                new StateHashReportResult(hashCodes));
     }
 
     @Override

--- a/src/main/java/exchange/core2/core/common/api/reports/StateHashReportResult.java
+++ b/src/main/java/exchange/core2/core/common/api/reports/StateHashReportResult.java
@@ -16,52 +16,111 @@
 package exchange.core2.core.common.api.reports;
 
 
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.ToString;
+import exchange.core2.core.utils.SerializationUtils;
+import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import net.openhft.chronicle.bytes.BytesIn;
 import net.openhft.chronicle.bytes.BytesOut;
+import net.openhft.chronicle.bytes.WriteBytesMarshallable;
+import org.jetbrains.annotations.NotNull;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
+import java.util.*;
 import java.util.stream.Stream;
 
-@AllArgsConstructor
 @Getter
 @Slf4j
 @EqualsAndHashCode
+@RequiredArgsConstructor
 @ToString
 public final class StateHashReportResult implements ReportResult {
 
-    private int stateHashRiskEngines;
-    private int stateHashMatcherEngines;
+    public static final StateHashReportResult EMPTY = new StateHashReportResult(new TreeMap<>());
+    private static final Comparator<SubmoduleKey> SUBMODULE_KEY_COMPARATOR =
+            Comparator.<SubmoduleKey>comparingInt(k -> k.submodule.code)
+                    .thenComparing(k -> k.moduleId);
+    private final SortedMap<SubmoduleKey, Integer> hashCodes;
 
     private StateHashReportResult(final BytesIn bytesIn) {
-        this.stateHashRiskEngines = bytesIn.readInt();
-        this.stateHashMatcherEngines = bytesIn.readInt();
-    }
 
-    @Override
-    public void writeMarshallable(final BytesOut bytes) {
-        bytes.writeInt(stateHashRiskEngines);
-        bytes.writeInt(stateHashMatcherEngines);
-    }
-
-    public int getStateHash() {
-        return Objects.hash(stateHashMatcherEngines, stateHashRiskEngines);
+        this.hashCodes = SerializationUtils.readGenericMap(bytesIn, TreeMap::new, SubmoduleKey::new, BytesIn::readInt);
     }
 
     public static StateHashReportResult merge(final Stream<BytesIn> pieces) {
 
-        final List<StateHashReportResult> results = pieces.map(StateHashReportResult::new).collect(Collectors.toList());
-        final int[] riskHashes = results.stream().mapToInt(StateHashReportResult::getStateHashRiskEngines).sorted().toArray();
-        final int[] matcherHashes = results.stream().mapToInt(StateHashReportResult::getStateHashMatcherEngines).sorted().toArray();
-
-        return new StateHashReportResult(Arrays.hashCode(riskHashes), Arrays.hashCode(matcherHashes));
+        return pieces.map(StateHashReportResult::new)
+                .reduce(EMPTY, (r1, r2) -> {
+                    SortedMap<SubmoduleKey, Integer> hashcodes = new TreeMap<>(r1.hashCodes);
+                    hashcodes.putAll(r2.hashCodes);
+                    return new StateHashReportResult(hashcodes);
+                });
     }
 
+    public static SubmoduleKey createKey(int moduleId, SubmoduleType submoduleType) {
+        return new SubmoduleKey(moduleId, submoduleType);
+    }
+
+    @Override
+    public void writeMarshallable(final BytesOut bytes) {
+        SerializationUtils.marshallGenericMap(hashCodes, bytes, (b, k) -> k.writeMarshallable(b), BytesOut::writeInt);
+    }
+
+    public int getStateHash() {
+
+        final int[] hashes = hashCodes.entrySet().stream()
+                .mapToInt(e -> Objects.hash(e.getKey(), e.getValue())).toArray();
+
+        return Arrays.hashCode(hashes);
+    }
+
+    public enum ModuleType {
+        RISK_ENGINE,
+        MATCHING_ENGINE
+    }
+
+    @AllArgsConstructor
+    public enum SubmoduleType {
+        RISK_SYMBOL_SPEC_PROVIDER(0, ModuleType.RISK_ENGINE),
+        RISK_USER_PROFILE_SERVICE(1, ModuleType.RISK_ENGINE),
+        RISK_BINARY_CMD_PROCESSOR(2, ModuleType.MATCHING_ENGINE),
+        RISK_LAST_PRICE_CACHE(3, ModuleType.RISK_ENGINE),
+        RISK_FEES(4, ModuleType.RISK_ENGINE),
+        RISK_ADJUSTMENTS(5, ModuleType.RISK_ENGINE),
+        RISK_SUSPENDS(6, ModuleType.RISK_ENGINE),
+        RISK_SHARD_MASK(7, ModuleType.RISK_ENGINE),
+
+        MATCHING_BINARY_CMD_PROCESSOR(64, ModuleType.MATCHING_ENGINE),
+        MATCHING_ORDER_BOOKS(65, ModuleType.MATCHING_ENGINE),
+        MATCHING_SHARD_MASK(66, ModuleType.MATCHING_ENGINE);
+
+        public final int code;
+        public final ModuleType moduleType;
+
+        public static SubmoduleType fromCode(int code) {
+            return Arrays.stream(values()).filter(c -> c.code == code).findFirst().orElseThrow(() -> new IllegalArgumentException("Unknown SubmoduleType"));
+        }
+    }
+
+    @RequiredArgsConstructor
+    @EqualsAndHashCode
+    public static final class SubmoduleKey implements WriteBytesMarshallable, Comparable<SubmoduleKey> {
+
+        public final int moduleId;
+        public final SubmoduleType submodule;
+
+        private SubmoduleKey(final BytesIn bytesIn) {
+            this.moduleId = bytesIn.readInt();
+            this.submodule = SubmoduleType.fromCode(bytesIn.readInt());
+        }
+
+        @Override
+        public void writeMarshallable(BytesOut bytes) {
+            bytes.writeInt(moduleId);
+            bytes.writeInt(submodule.code);
+        }
+
+        @Override
+        public int compareTo(@NotNull SubmoduleKey o) {
+            return SUBMODULE_KEY_COMPARATOR.compare(this, o);
+        }
+    }
 }

--- a/src/main/java/exchange/core2/core/common/api/reports/TotalCurrencyBalanceReportQuery.java
+++ b/src/main/java/exchange/core2/core/common/api/reports/TotalCurrencyBalanceReportQuery.java
@@ -31,7 +31,6 @@ import org.eclipse.collections.impl.map.mutable.primitive.IntLongHashMap;
 import org.eclipse.collections.impl.map.mutable.primitive.IntObjectHashMap;
 
 import java.util.Optional;
-import java.util.function.Function;
 import java.util.stream.Stream;
 
 @NoArgsConstructor
@@ -49,12 +48,12 @@ public final class TotalCurrencyBalanceReportQuery implements ReportQuery<TotalC
     }
 
     @Override
-    public Function<Stream<BytesIn>, TotalCurrencyBalanceReportResult> getResultBuilder() {
-        return TotalCurrencyBalanceReportResult::merge;
+    public TotalCurrencyBalanceReportResult createResult(final Stream<BytesIn> sections) {
+        return TotalCurrencyBalanceReportResult.merge(sections);
     }
 
     @Override
-    public Optional<TotalCurrencyBalanceReportResult> process(MatchingEngineRouter matchingEngine) {
+    public Optional<TotalCurrencyBalanceReportResult> process(final MatchingEngineRouter matchingEngine) {
 
         final IntLongHashMap currencyBalance = new IntLongHashMap();
 
@@ -76,7 +75,7 @@ public final class TotalCurrencyBalanceReportQuery implements ReportQuery<TotalC
     }
 
     @Override
-    public Optional<TotalCurrencyBalanceReportResult> process(RiskEngine riskEngine) {
+    public Optional<TotalCurrencyBalanceReportResult> process(final RiskEngine riskEngine) {
 
         // prepare fast price cache for profit estimation with some price (exact value is not important, except ask==bid condition)
         final IntObjectHashMap<RiskEngine.LastPriceCacheRecord> dummyLastPriceCache = new IntObjectHashMap<>();

--- a/src/main/java/exchange/core2/core/orderbook/IOrderBook.java
+++ b/src/main/java/exchange/core2/core/orderbook/IOrderBook.java
@@ -27,6 +27,7 @@ import net.openhft.chronicle.bytes.BytesIn;
 import net.openhft.chronicle.bytes.WriteBytesMarshallable;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 public interface IOrderBook extends WriteBytesMarshallable, StateHash {
@@ -118,7 +119,19 @@ public interface IOrderBook extends WriteBytesMarshallable, StateHash {
      */
     @Override
     default int stateHash() {
-        return HashingUtils.stateHash(this);
+
+        // log.debug("State hash of {}", orderBook.getClass().getSimpleName());
+        // log.debug("  Ask orders stream: {}", orderBook.askOrdersStream(true).collect(Collectors.toList()));
+        // log.debug("  Ask orders hash: {}", stateHashStream(orderBook.askOrdersStream(true)));
+        // log.debug("  Bid orders stream: {}", orderBook.bidOrdersStream(true).collect(Collectors.toList()));
+        // log.debug("  Bid orders hash: {}", stateHashStream(orderBook.bidOrdersStream(true)));
+        // log.debug("  getSymbolSpec: {}", orderBook.getSymbolSpec());
+        // log.debug("  getSymbolSpec hash: {}", orderBook.getSymbolSpec().stateHash());
+
+        return Objects.hash(
+                HashingUtils.stateHashStream(askOrdersStream(true)),
+                HashingUtils.stateHashStream(bidOrdersStream(true)),
+                getSymbolSpec().stateHash());
     }
 
     /**

--- a/src/main/java/exchange/core2/core/orderbook/OrderBookEventsHelper.java
+++ b/src/main/java/exchange/core2/core/orderbook/OrderBookEventsHelper.java
@@ -25,12 +25,8 @@ import lombok.extern.slf4j.Slf4j;
 import net.openhft.chronicle.bytes.NativeBytes;
 import net.openhft.chronicle.wire.Wire;
 
-import java.util.List;
-import java.util.Map;
-import java.util.NavigableMap;
-import java.util.TreeMap;
+import java.util.*;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static exchange.core2.core.ExchangeCore.EVENTS_POOLING;
@@ -160,11 +156,10 @@ public final class OrderBookEventsHelper {
     }
 
 
-    public static NavigableMap<Integer, Wire> deserializeEvents(final MatcherTradeEvent evtHead) {
+    public static NavigableMap<Integer, Wire> deserializeEvents(final OrderCommand cmd) {
 
-        // TODO Optimize
-        final Map<Integer, List<MatcherTradeEvent>> sections = MatcherTradeEvent.asList(evtHead).stream()
-                .collect(Collectors.groupingBy(evt -> evt.section, Collectors.toList()));
+        final Map<Integer, List<MatcherTradeEvent>> sections = new HashMap<>();
+        cmd.processMatcherEvents(evt -> sections.computeIfAbsent(evt.section, k -> new ArrayList<>()).add(evt));
 
         NavigableMap<Integer, Wire> result = new TreeMap<>();
 

--- a/src/main/java/exchange/core2/core/processors/MatchingEngineRouter.java
+++ b/src/main/java/exchange/core2/core/processors/MatchingEngineRouter.java
@@ -17,7 +17,6 @@ package exchange.core2.core.processors;
 
 import exchange.core2.collections.objpool.ObjectsPool;
 import exchange.core2.core.common.CoreSymbolSpecification;
-import exchange.core2.core.common.StateHash;
 import exchange.core2.core.common.SymbolType;
 import exchange.core2.core.common.api.binary.BatchAddAccountsCommand;
 import exchange.core2.core.common.api.binary.BatchAddSymbolsCommand;
@@ -32,7 +31,6 @@ import exchange.core2.core.common.config.OrdersProcessingConfiguration;
 import exchange.core2.core.orderbook.IOrderBook;
 import exchange.core2.core.orderbook.OrderBookEventsHelper;
 import exchange.core2.core.processors.journaling.ISerializationProcessor;
-import exchange.core2.core.utils.HashingUtils;
 import exchange.core2.core.utils.SerializationUtils;
 import exchange.core2.core.utils.UnsafeUtils;
 import lombok.Builder;
@@ -44,12 +42,11 @@ import net.openhft.chronicle.bytes.WriteBytesMarshallable;
 import org.eclipse.collections.impl.map.mutable.primitive.IntObjectHashMap;
 
 import java.util.HashMap;
-import java.util.Objects;
 import java.util.Optional;
 
 @Slf4j
 @Getter
-public final class MatchingEngineRouter implements WriteBytesMarshallable, StateHash {
+public final class MatchingEngineRouter implements WriteBytesMarshallable {
 
     // state
     private final BinaryCommandsProcessor binaryCommandsProcessor;
@@ -255,16 +252,6 @@ public final class MatchingEngineRouter implements WriteBytesMarshallable, State
 
         // write orderBooks
         SerializationUtils.marshallIntHashMap(orderBooks, bytes);
-    }
-
-    @Override
-    public int stateHash() {
-//        log.debug("HASH ME{} : HashingUtils.stateHash(orderBooks)={}", shardId, HashingUtils.stateHash(orderBooks));
-        return Objects.hash(
-                shardId,
-                shardMask,
-                binaryCommandsProcessor.stateHash(),
-                HashingUtils.stateHash(orderBooks));
     }
 
     @Builder

--- a/src/main/java/exchange/core2/core/processors/RiskEngine.java
+++ b/src/main/java/exchange/core2/core/processors/RiskEngine.java
@@ -30,7 +30,6 @@ import exchange.core2.core.common.config.LoggingConfiguration;
 import exchange.core2.core.common.config.OrdersProcessingConfiguration;
 import exchange.core2.core.processors.journaling.ISerializationProcessor;
 import exchange.core2.core.utils.CoreArithmeticUtils;
-import exchange.core2.core.utils.HashingUtils;
 import exchange.core2.core.utils.SerializationUtils;
 import exchange.core2.core.utils.UnsafeUtils;
 import lombok.AllArgsConstructor;
@@ -53,7 +52,7 @@ import java.util.Optional;
  */
 @Slf4j
 @Getter
-public final class RiskEngine implements WriteBytesMarshallable, StateHash {
+public final class RiskEngine implements WriteBytesMarshallable {
 
     // state
     private final SymbolSpecificationProvider symbolSpecificationProvider;
@@ -802,23 +801,6 @@ public final class RiskEngine implements WriteBytesMarshallable, StateHash {
         fees.clear();
         adjustments.clear();
         suspends.clear();
-    }
-
-    @Override
-    public int stateHash() {
-
-        return Objects.hash(
-                shardId,
-                shardMask,
-                symbolSpecificationProvider.stateHash(),
-                userProfileService.stateHash(),
-                binaryCommandsProcessor.stateHash(),
-                HashingUtils.stateHash(lastPriceCache),
-                fees.hashCode(),
-                adjustments.hashCode(),
-                suspends.hashCode());
-
-        //log.debug("HASH RE{}/{} hash={} -- ssp={} ups={} bcp={} lpc={}", shardId, shardMask, hash, symbolSpecificationProvider.stateHash(), userProfileService.stateHash(), binaryCommandsProcessor.stateHash(), lastPriceCache.hashCode());
     }
 
     @AllArgsConstructor

--- a/src/main/java/exchange/core2/core/processors/TwoStepMasterProcessor.java
+++ b/src/main/java/exchange/core2/core/processors/TwoStepMasterProcessor.java
@@ -135,7 +135,6 @@ public final class TwoStepMasterProcessor implements EventProcessor {
 
                         if (cmd.command == OrderCommandType.SHUTDOWN_SIGNAL) {
                             // having all sequences aligned with the ringbuffer cursor is a requirement for proper shutdown
-
                             // let following processors to catch up
                             publishProgressAndTriggerSlaveProcessor(nextSequence);
                         }
@@ -157,7 +156,7 @@ public final class TwoStepMasterProcessor implements EventProcessor {
         }
     }
 
-    private void publishProgressAndTriggerSlaveProcessor(long nextSequence) {
+    private void publishProgressAndTriggerSlaveProcessor(final long nextSequence) {
         sequence.set(nextSequence - 1);
         waitSpinningHelper.signalAllWhenBlocking();
         slaveProcessor.handlingCycle(nextSequence);

--- a/src/main/java/exchange/core2/core/processors/UserProfileService.java
+++ b/src/main/java/exchange/core2/core/processors/UserProfileService.java
@@ -28,8 +28,6 @@ import net.openhft.chronicle.bytes.BytesOut;
 import net.openhft.chronicle.bytes.WriteBytesMarshallable;
 import org.eclipse.collections.impl.map.mutable.primitive.LongObjectHashMap;
 
-import java.util.Objects;
-
 /**
  * Stateful (!) User profile service
  * <p>
@@ -191,7 +189,7 @@ public final class UserProfileService implements WriteBytesMarshallable, StateHa
 
     @Override
     public int stateHash() {
-        return Objects.hash(HashingUtils.stateHash(userProfiles));
+        return HashingUtils.stateHash(userProfiles);
     }
 
 }

--- a/src/main/java/exchange/core2/core/utils/SerializationUtils.java
+++ b/src/main/java/exchange/core2/core/utils/SerializationUtils.java
@@ -325,6 +325,30 @@ public final class SerializationUtils {
         return map;
     }
 
+    public static <K, V> void marshallGenericMap(final Map<K, V> map,
+                                                 final BytesOut bytes,
+                                                 final BiConsumer<BytesOut, K> keyMarshaller,
+                                                 final BiConsumer<BytesOut, V> valMarshaller) {
+        bytes.writeInt(map.size());
+
+        map.forEach((k, v) -> {
+            keyMarshaller.accept(bytes, k);
+            valMarshaller.accept(bytes, v);
+        });
+    }
+
+    public static <K, V, M extends Map<K, V>> M readGenericMap(final BytesIn bytes,
+                                                               final Supplier<M> mapSupplier,
+                                                               final Function<BytesIn, K> keyCreator,
+                                                               final Function<BytesIn, V> valCreator) {
+        int length = bytes.readInt();
+        final M map = mapSupplier.get();
+        for (int i = 0; i < length; i++) {
+            map.put(keyCreator.apply(bytes), valCreator.apply(bytes));
+        }
+        return map;
+    }
+
     public static <T extends WriteBytesMarshallable> void marshallList(final List<T> list, final BytesOut bytes) {
         bytes.writeInt(list.size());
         list.forEach(v -> v.writeMarshallable(bytes));

--- a/src/test/java/exchange/core2/tests/RunCukesDirectLatencyTests.java
+++ b/src/test/java/exchange/core2/tests/RunCukesDirectLatencyTests.java
@@ -12,7 +12,7 @@ import org.junit.runner.RunWith;
 @RunWith(Cucumber.class)
 @CucumberOptions(plugin = {"pretty", "html:target/cucumber"}, strict = true)
 @Slf4j
-public class RunCukesDirectTests {
+public class RunCukesDirectLatencyTests {
 
     @BeforeClass
     public static void beforeClass() {

--- a/src/test/java/exchange/core2/tests/RunCukesDirectThroughputTests.java
+++ b/src/test/java/exchange/core2/tests/RunCukesDirectThroughputTests.java
@@ -1,0 +1,27 @@
+package exchange.core2.tests;
+
+import exchange.core2.core.common.config.PerformanceConfiguration;
+import exchange.core2.tests.steps.OrderStepdefs;
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(plugin = {"pretty", "html:target/cucumber"}, strict = true)
+@Slf4j
+public class RunCukesDirectThroughputTests {
+
+    @BeforeClass
+    public static void beforeClass() {
+        OrderStepdefs.testPerformanceConfiguration = PerformanceConfiguration.throughputPerformanceBuilder().build();
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        OrderStepdefs.testPerformanceConfiguration = null;
+    }
+
+}

--- a/src/test/resources/exchange/core2/tests/features/basic.feature
+++ b/src/test/resources/exchange/core2/tests/features/basic.feature
@@ -65,5 +65,11 @@ Feature: An exchange accepts bid\ask orders, manage and publish order book and m
       | id  | price | size | filled | reservePrice | side |
       | 203 | 18500 | 500  | 0      | 18500        | BID  |
 
-    When A client Charlie cancels the remaining size 500 of the order 203
+    And An ETH_XBT order book is:
+      | 500 | 18500 |  |
 
+    When A client Charlie cancels the remaining size 500 of the order 203
+    Then A client Charlie does not have active orders
+    And A balance of a client Charlie:
+      | ETH | 0        |
+      | XBT | 94000000 |


### PR DESCRIPTION
bugfix - avoid possible deadlock when using blocking wait strategy; 
bugfix - incorrect speculative move rejection; 
dump configuration on startup; 
improve test commands generation; 
make cucumber tests cover each major configuration; 
improve unit tests; 
optimize pom.xml; 
detailed hashstate report; 
faster hash state calculation for hashmaps.