### PR TITLE
Stop Loss/Take Profit Integration

### DIFF
--- a/src/main/java/exchange/core2/core/common/Order.java
+++ b/src/main/java/exchange/core2/core/common/Order.java
@@ -53,6 +53,9 @@ public final class Order implements WriteBytesMarshallable, IOrder {
     @Getter
     public long reserveBidPrice;
 
+    @Getter
+    public long stopPrice;
+
     // required for PLACE_ORDER only;
     @Getter
     public OrderAction action;
@@ -73,6 +76,7 @@ public final class Order implements WriteBytesMarshallable, IOrder {
         this.size = bytes.readLong(); // size
         this.filled = bytes.readLong(); // filled
         this.reserveBidPrice = bytes.readLong(); // price2
+        this.stopPrice = bytes.readLong(); // price2
         this.action = OrderAction.of(bytes.readByte());
         this.uid = bytes.readLong(); // uid
         this.timestamp = bytes.readLong(); // timestamp
@@ -87,6 +91,7 @@ public final class Order implements WriteBytesMarshallable, IOrder {
         bytes.writeLong(size);
         bytes.writeLong(filled);
         bytes.writeLong(reserveBidPrice);
+        bytes.writeLong(stopPrice);
         bytes.writeByte(action.getCode());
         bytes.writeLong(uid);
         bytes.writeLong(timestamp);
@@ -103,7 +108,7 @@ public final class Order implements WriteBytesMarshallable, IOrder {
 
     @Override
     public int hashCode() {
-        return Objects.hash(orderId, action, price, size, reserveBidPrice, filled,
+        return Objects.hash(orderId, action, price, size, reserveBidPrice, stopPrice, filled,
                 //userCookie, timestamp
                 uid);
     }
@@ -126,6 +131,7 @@ public final class Order implements WriteBytesMarshallable, IOrder {
                 && price == other.price
                 && size == other.size
                 && reserveBidPrice == other.reserveBidPrice
+                && stopPrice == other.stopPrice
                 && filled == other.filled
                 && uid == other.uid;
     }

--- a/src/main/java/exchange/core2/core/common/OrderType.java
+++ b/src/main/java/exchange/core2/core/common/OrderType.java
@@ -29,7 +29,8 @@ public enum OrderType {
 
     // Fill or Kill - execute immediately completely or not at all
     FOK(3), // with price cap
-    FOK_BUDGET(4); // total amount cap
+    FOK_BUDGET(4), // total amount cap
+    STOP_LOSS(5);
 
     private final byte code;
 
@@ -49,6 +50,8 @@ public enum OrderType {
                 return FOK;
             case 4:
                 return FOK_BUDGET;
+            case 5:
+                return STOP_LOSS;
             default:
                 throw new IllegalArgumentException("unknown OrderType:" + code);
         }

--- a/src/main/java/exchange/core2/core/common/cmd/OrderCommand.java
+++ b/src/main/java/exchange/core2/core/common/cmd/OrderCommand.java
@@ -45,6 +45,9 @@ public final class OrderCommand implements IOrder {
     // new orders INPUT - reserved price for fast moves of GTC bid orders in exchange mode
     public long reserveBidPrice;
 
+    @Getter
+    public long stopPrice;
+
     // required for PLACE_ORDER only;
     // for CANCEL/MOVE contains original order action (filled by orderbook)
     @Getter
@@ -78,13 +81,14 @@ public final class OrderCommand implements IOrder {
     //public long matcherEventSequence;
     // ---- potential false sharing section ------
 
-    public static OrderCommand newOrder(OrderType orderType, long orderId, long uid, long price, long reserveBidPrice, long size, OrderAction action) {
+    public static OrderCommand newOrder(OrderType orderType, long orderId, long uid, long price, long reserveBidPrice, long stopPrice, long size, OrderAction action) {
         OrderCommand cmd = new OrderCommand();
         cmd.command = OrderCommandType.PLACE_ORDER;
         cmd.orderId = orderId;
         cmd.uid = uid;
         cmd.price = price;
         cmd.reserveBidPrice = reserveBidPrice;
+        cmd.stopPrice = stopPrice;
         cmd.size = size;
         cmd.action = action;
         cmd.orderType = orderType;
@@ -172,6 +176,7 @@ public final class OrderCommand implements IOrder {
         cmd2.timestamp = this.timestamp;
 
         cmd2.reserveBidPrice = this.reserveBidPrice;
+        cmd2.stopPrice = this.stopPrice;
         cmd2.price = this.price;
         cmd2.size = this.size;
         cmd2.action = this.action;

--- a/src/main/java/exchange/core2/core/orderbook/OrderBookNaiveImpl.java
+++ b/src/main/java/exchange/core2/core/orderbook/OrderBookNaiveImpl.java
@@ -362,7 +362,7 @@ public final class OrderBookNaiveImpl implements IOrderBook {
         //final NavigableMap<Long, List<Order>> slMap = (Action == OrderAction.ASK) ? askMapSL : bidMapSL;
         final ConcurrentHashMap<Long, List<Order>> slMap = (Action == OrderAction.ASK) ? askMapSL : bidMapSL;
 
-        if(rangeList.isEmpty() == false) {
+        if(rangeList.size() > 0) {
             List listResult = (Action == OrderAction.ASK)
                     ? rangeList.stream()
                     .filter(s -> s <= roundedPrice)
@@ -392,17 +392,22 @@ public final class OrderBookNaiveImpl implements IOrderBook {
 
                                 final OrderAction oAction = (Action == OrderAction.ASK) ? OrderAction.ASK : OrderAction.BID;
                                 getBucketsByAction(oAction)
-                                        .computeIfAbsent(price, OrdersBucketNaive::new)
+                                        .computeIfAbsent(order.price, OrdersBucketNaive::new)
                                         .put(order);
 
                                 idMap.put(slOrderId, order);
 
                                 //remove it from previous map
-                                currentList.remove(order);
+                                currentList.remove(slOrderId);
                             }
                         });
-                        // save new list to map
-                        slMap.put(roundedPriceKey, currentList);
+
+                        // save new list to map or remove it if empty
+                        if(currentList.size() > 0) {
+                            slMap.put(roundedPriceKey, currentList);
+                        } else {
+                            slMap.remove(roundedPriceKey);
+                        }
 
                     }
                 }

--- a/src/test/java/exchange/core2/core/orderbook/OrderBookBaseTest.java
+++ b/src/test/java/exchange/core2/core/orderbook/OrderBookBaseTest.java
@@ -71,23 +71,23 @@ public abstract class OrderBookBaseTest {
         orderBook = createNewOrderBook();
         orderBook.validateInternalState();
 
-        processAndValidate(OrderCommand.newOrder(GTC, 0L, UID_2, INITIAL_PRICE, 0L, 13L, ASK), SUCCESS);
+        processAndValidate(OrderCommand.newOrder(GTC, 0L, UID_2, INITIAL_PRICE, 0L, 0L, 13L, ASK), SUCCESS);
         processAndValidate(OrderCommand.cancel(0L, UID_2), SUCCESS);
 
-        processAndValidate(OrderCommand.newOrder(GTC, 1L, UID_1, 81600L, 0L, 100L, ASK), SUCCESS);
-        processAndValidate(OrderCommand.newOrder(GTC, 2L, UID_1, 81599L, 0L, 50L, ASK), SUCCESS);
-        processAndValidate(OrderCommand.newOrder(GTC, 3L, UID_1, 81599L, 0L, 25L, ASK), SUCCESS);
-        processAndValidate(OrderCommand.newOrder(GTC, 8L, UID_1, 201000L, 0L, 28L, ASK), SUCCESS);
-        processAndValidate(OrderCommand.newOrder(GTC, 9L, UID_1, 201000L, 0L, 32L, ASK), SUCCESS);
-        processAndValidate(OrderCommand.newOrder(GTC, 10L, UID_1, 200954L, 0L, 10L, ASK), SUCCESS);
+        processAndValidate(OrderCommand.newOrder(GTC, 1L, UID_1, 81600L, 0L, 0L, 100L, ASK), SUCCESS);
+        processAndValidate(OrderCommand.newOrder(GTC, 2L, UID_1, 81599L, 0L, 0L,50L, ASK), SUCCESS);
+        processAndValidate(OrderCommand.newOrder(GTC, 3L, UID_1, 81599L, 0L, 0L,25L, ASK), SUCCESS);
+        processAndValidate(OrderCommand.newOrder(GTC, 8L, UID_1, 201000L, 0L, 0L,28L, ASK), SUCCESS);
+        processAndValidate(OrderCommand.newOrder(GTC, 9L, UID_1, 201000L, 0L, 0L,32L, ASK), SUCCESS);
+        processAndValidate(OrderCommand.newOrder(GTC, 10L, UID_1, 200954L, 0L, 0L,10L, ASK), SUCCESS);
 
-        processAndValidate(OrderCommand.newOrder(GTC, 4L, UID_1, 81593L, 82000L, 40L, BID), SUCCESS);
-        processAndValidate(OrderCommand.newOrder(GTC, 5L, UID_1, 81590L, 82000L, 20L, BID), SUCCESS);
-        processAndValidate(OrderCommand.newOrder(GTC, 6L, UID_1, 81590L, 82000L, 1L, BID), SUCCESS);
-        processAndValidate(OrderCommand.newOrder(GTC, 7L, UID_1, 81200L, 82000L, 20L, BID), SUCCESS);
-        processAndValidate(OrderCommand.newOrder(GTC, 11L, UID_1, 10000L, 12000L, 12L, BID), SUCCESS);
-        processAndValidate(OrderCommand.newOrder(GTC, 12L, UID_1, 10000L, 12000L, 1L, BID), SUCCESS);
-        processAndValidate(OrderCommand.newOrder(GTC, 13L, UID_1, 9136L, 12000L, 2L, BID), SUCCESS);
+        processAndValidate(OrderCommand.newOrder(GTC, 4L, UID_1, 81593L, 82000L, 0L,40L, BID), SUCCESS);
+        processAndValidate(OrderCommand.newOrder(GTC, 5L, UID_1, 81590L, 82000L, 0L,20L, BID), SUCCESS);
+        processAndValidate(OrderCommand.newOrder(GTC, 6L, UID_1, 81590L, 82000L, 0L,1L, BID), SUCCESS);
+        processAndValidate(OrderCommand.newOrder(GTC, 7L, UID_1, 81200L, 82000L, 0L,20L, BID), SUCCESS);
+        processAndValidate(OrderCommand.newOrder(GTC, 11L, UID_1, 10000L, 12000L, 0L,12L, BID), SUCCESS);
+        processAndValidate(OrderCommand.newOrder(GTC, 12L, UID_1, 10000L, 12000L, 0L,1L, BID), SUCCESS);
+        processAndValidate(OrderCommand.newOrder(GTC, 13L, UID_1, 9136L, 12000L, 0L,2L, BID), SUCCESS);
 
         expectedState = new L2MarketDataHelper(
                 new L2MarketData(
@@ -119,7 +119,7 @@ public abstract class OrderBookBaseTest {
 
         // match all asks
         long askSum = Arrays.stream(snapshot.askVolumes).sum();
-        IOrderBook.processCommand(orderBook, OrderCommand.newOrder(IOC, 100000000000L, -1, MAX_PRICE, MAX_PRICE, askSum, BID));
+        IOrderBook.processCommand(orderBook, OrderCommand.newOrder(IOC, 100000000000L, -1, MAX_PRICE, MAX_PRICE, 0L,askSum, BID));
 
 //        log.debug("{}", orderBook.getL2MarketDataSnapshot(Integer.MAX_VALUE).dumpOrderBook());
 
@@ -127,7 +127,7 @@ public abstract class OrderBookBaseTest {
 
         // match all bids
         long bidSum = Arrays.stream(snapshot.bidVolumes).sum();
-        IOrderBook.processCommand(orderBook, OrderCommand.newOrder(IOC, 100000000001L, -2, 1, 0, bidSum, ASK));
+        IOrderBook.processCommand(orderBook, OrderCommand.newOrder(IOC, 100000000001L, -2, 1, 0, 0L,bidSum, ASK));
 
 //        log.debug("{}", orderBook.getL2MarketDataSnapshot(Integer.MAX_VALUE).dumpOrderBook());
 
@@ -151,20 +151,20 @@ public abstract class OrderBookBaseTest {
     @Test
     public void shouldAddGtcOrders() {
 
-        IOrderBook.processCommand(orderBook, OrderCommand.newOrder(GTC, 93, UID_1, 81598, 0, 1, ASK));
+        IOrderBook.processCommand(orderBook, OrderCommand.newOrder(GTC, 93, UID_1, 81598, 0, 0L,1, ASK));
         expectedState.insertAsk(0, 81598, 1);
 
-        IOrderBook.processCommand(orderBook, OrderCommand.newOrder(GTC, 94, UID_1, 81594, MAX_PRICE, 9_000_000_000L, BID));
+        IOrderBook.processCommand(orderBook, OrderCommand.newOrder(GTC, 94, UID_1, 81594, MAX_PRICE, 0L,9_000_000_000L, BID));
         expectedState.insertBid(0, 81594, 9_000_000_000L);
 
         L2MarketData snapshot = orderBook.getL2MarketDataSnapshot(25);
         assertEquals(expectedState.build(), snapshot);
         orderBook.validateInternalState();
 
-        IOrderBook.processCommand(orderBook, OrderCommand.newOrder(GTC, 95, UID_1, 130000, 0, 13_000_000_000L, ASK));
+        IOrderBook.processCommand(orderBook, OrderCommand.newOrder(GTC, 95, UID_1, 130000, 0, 0L,13_000_000_000L, ASK));
         expectedState.insertAsk(3, 130000, 13_000_000_000L);
 
-        IOrderBook.processCommand(orderBook, OrderCommand.newOrder(GTC, 96, UID_1, 1000, MAX_PRICE, 4, BID));
+        IOrderBook.processCommand(orderBook, OrderCommand.newOrder(GTC, 96, UID_1, 1000, MAX_PRICE, 0L,4, BID));
         expectedState.insertBid(6, 1000, 4);
 
         snapshot = orderBook.getL2MarketDataSnapshot(25);
@@ -179,7 +179,7 @@ public abstract class OrderBookBaseTest {
      */
     @Test
     public void shouldIgnoredDuplicateOrder() {
-        OrderCommand orderCommand = OrderCommand.newOrder(GTC, 1, UID_1, 81600, 0, 100, ASK);
+        OrderCommand orderCommand = OrderCommand.newOrder(GTC, 1, UID_1, 81600, 0, 0L,100, ASK);
         processAndValidate(orderCommand, SUCCESS);
         List<MatcherTradeEvent> events = orderCommand.extractEvents();
         assertThat(events.size(), is(1));
@@ -405,7 +405,7 @@ public abstract class OrderBookBaseTest {
     public void shouldMatchIocOrderPartialBBO() {
 
         // size=10
-        OrderCommand cmd = OrderCommand.newOrder(IOC, 123, UID_2, 1, 0, 10, ASK);
+        OrderCommand cmd = OrderCommand.newOrder(IOC, 123, UID_2, 1, 0, 0L,10, ASK);
         processAndValidate(cmd, SUCCESS);
 
         L2MarketData snapshot = orderBook.getL2MarketDataSnapshot(10);
@@ -423,7 +423,7 @@ public abstract class OrderBookBaseTest {
     public void shouldMatchIocOrderFullBBO() {
 
         // size=40
-        OrderCommand cmd = OrderCommand.newOrder(IOC, 123, UID_2, 1, 0, 40, ASK);
+        OrderCommand cmd = OrderCommand.newOrder(IOC, 123, UID_2, 1, 0, 0L,40, ASK);
         processAndValidate(cmd, SUCCESS);
 
         L2MarketData snapshot = orderBook.getL2MarketDataSnapshot(10);
@@ -440,7 +440,7 @@ public abstract class OrderBookBaseTest {
     public void shouldMatchIocOrderWithTwoLimitOrdersPartial() {
 
         // size=41
-        OrderCommand cmd = OrderCommand.newOrder(IOC, 123, UID_2, 1, 0, 41, ASK);
+        OrderCommand cmd = OrderCommand.newOrder(IOC, 123, UID_2, 1, 0, 0L,41, ASK);
         processAndValidate(cmd, SUCCESS);
 
         L2MarketData snapshot = orderBook.getL2MarketDataSnapshot(10);
@@ -463,7 +463,7 @@ public abstract class OrderBookBaseTest {
     public void shouldMatchIocOrderFullLiquidity() {
 
         // size=175
-        OrderCommand cmd = OrderCommand.newOrder(IOC, 123, UID_2, MAX_PRICE, MAX_PRICE, 175, BID);
+        OrderCommand cmd = OrderCommand.newOrder(IOC, 123, UID_2, MAX_PRICE, MAX_PRICE, 0L,175, BID);
         processAndValidate(cmd, SUCCESS);
 
         L2MarketData snapshot = orderBook.getL2MarketDataSnapshot(10);
@@ -487,7 +487,7 @@ public abstract class OrderBookBaseTest {
     public void shouldMatchIocOrderWithRejection() {
 
         // size=270
-        OrderCommand cmd = OrderCommand.newOrder(IOC, 123, UID_2, MAX_PRICE, MAX_PRICE + 1, 270, BID);
+        OrderCommand cmd = OrderCommand.newOrder(IOC, 123, UID_2, MAX_PRICE, MAX_PRICE + 1, 0L,270, BID);
         processAndValidate(cmd, SUCCESS);
 
         L2MarketData snapshot = orderBook.getL2MarketDataSnapshot(10);
@@ -511,7 +511,7 @@ public abstract class OrderBookBaseTest {
         long buyBudget = expectedState.aggregateBuyBudget(size) - 1;
         assertThat(buyBudget, Is.is(81599L * 75L + 81600L * 100L + 200954L * 5L - 1));
 
-        OrderCommand cmd = OrderCommand.newOrder(FOK_BUDGET, 123L, UID_2, buyBudget, buyBudget, size, BID);
+        OrderCommand cmd = OrderCommand.newOrder(FOK_BUDGET, 123L, UID_2, buyBudget, buyBudget, 0L,size, BID);
         processAndValidate(cmd, SUCCESS);
 
         L2MarketData snapshot = orderBook.getL2MarketDataSnapshot(10);
@@ -531,7 +531,7 @@ public abstract class OrderBookBaseTest {
         long buyBudget = expectedState.aggregateBuyBudget(size);
         assertThat(buyBudget, Is.is(81599L * 75L + 81600L * 100L + 200954L * 5L));
 
-        OrderCommand cmd = OrderCommand.newOrder(FOK_BUDGET, 123L, UID_2, buyBudget, buyBudget, size, BID);
+        OrderCommand cmd = OrderCommand.newOrder(FOK_BUDGET, 123L, UID_2, buyBudget, buyBudget, 0L,size, BID);
         processAndValidate(cmd, SUCCESS);
 
         L2MarketData snapshot = orderBook.getL2MarketDataSnapshot(10);
@@ -552,7 +552,7 @@ public abstract class OrderBookBaseTest {
         long buyBudget = expectedState.aggregateBuyBudget(size) + 1;
         assertThat(buyBudget, Is.is(81599L * 75L + 81600L * 100L + 200954L + 1L));
 
-        OrderCommand cmd = OrderCommand.newOrder(FOK_BUDGET, 123L, UID_2, buyBudget, buyBudget, size, BID);
+        OrderCommand cmd = OrderCommand.newOrder(FOK_BUDGET, 123L, UID_2, buyBudget, buyBudget, 0L,size, BID);
         processAndValidate(cmd, SUCCESS);
 
         L2MarketData snapshot = orderBook.getL2MarketDataSnapshot(10);
@@ -573,7 +573,7 @@ public abstract class OrderBookBaseTest {
         long sellExpectation = expectedState.aggregateSellExpectation(size) + 1;
         assertThat(sellExpectation, Is.is(81593L * 40L + 81590L * 20L + 1));
 
-        OrderCommand cmd = OrderCommand.newOrder(FOK_BUDGET, 123L, UID_2, sellExpectation, sellExpectation, size, ASK);
+        OrderCommand cmd = OrderCommand.newOrder(FOK_BUDGET, 123L, UID_2, sellExpectation, sellExpectation, 0L,size, ASK);
         processAndValidate(cmd, SUCCESS);
 
         L2MarketData snapshot = orderBook.getL2MarketDataSnapshot(10);
@@ -592,7 +592,7 @@ public abstract class OrderBookBaseTest {
         long sellExpectation = expectedState.aggregateSellExpectation(size);
         assertThat(sellExpectation, Is.is(81593L * 40L + 81590L * 20L));
 
-        OrderCommand cmd = OrderCommand.newOrder(FOK_BUDGET, 123L, UID_2, sellExpectation, sellExpectation, size, ASK);
+        OrderCommand cmd = OrderCommand.newOrder(FOK_BUDGET, 123L, UID_2, sellExpectation, sellExpectation, 0L,size, ASK);
         processAndValidate(cmd, SUCCESS);
 
         L2MarketData snapshot = orderBook.getL2MarketDataSnapshot(10);
@@ -611,7 +611,7 @@ public abstract class OrderBookBaseTest {
         long sellExpectation = expectedState.aggregateSellExpectation(size) - 1;
         assertThat(sellExpectation, Is.is(81593L * 40L + 81590L * 21L - 1));
 
-        OrderCommand cmd = OrderCommand.newOrder(FOK_BUDGET, 123L, UID_2, sellExpectation, sellExpectation, size, ASK);
+        OrderCommand cmd = OrderCommand.newOrder(FOK_BUDGET, 123L, UID_2, sellExpectation, sellExpectation, 0L,size, ASK);
         processAndValidate(cmd, SUCCESS);
 
         L2MarketData snapshot = orderBook.getL2MarketDataSnapshot(10);
@@ -631,7 +631,7 @@ public abstract class OrderBookBaseTest {
     public void shouldFullyMatchMarketableGtcOrder() {
 
         // size=1
-        OrderCommand cmd = OrderCommand.newOrder(GTC, 123, UID_2, 81599, MAX_PRICE, 1, BID);
+        OrderCommand cmd = OrderCommand.newOrder(GTC, 123, UID_2, 81599, MAX_PRICE, 0L,1, BID);
         processAndValidate(cmd, SUCCESS);
 
         L2MarketData snapshot = orderBook.getL2MarketDataSnapshot(10);
@@ -649,7 +649,7 @@ public abstract class OrderBookBaseTest {
     public void shouldPartiallyMatchMarketableGtcOrderAndPlace() {
 
         // size=77
-        OrderCommand cmd = OrderCommand.newOrder(GTC, 123, UID_2, 81599, MAX_PRICE, 77, BID);
+        OrderCommand cmd = OrderCommand.newOrder(GTC, 123, UID_2, 81599, MAX_PRICE, 0L,77, BID);
         processAndValidate(cmd, SUCCESS);
 
         L2MarketData snapshot = orderBook.getL2MarketDataSnapshot(10);
@@ -668,7 +668,7 @@ public abstract class OrderBookBaseTest {
     public void shouldFullyMatchMarketableGtcOrder2Prices() {
 
         // size=77
-        OrderCommand cmd = OrderCommand.newOrder(GTC, 123, UID_2, 81600, MAX_PRICE, 77, BID);
+        OrderCommand cmd = OrderCommand.newOrder(GTC, 123, UID_2, 81600, MAX_PRICE, 0L,77, BID);
         processAndValidate(cmd, SUCCESS);
 
         L2MarketData snapshot = orderBook.getL2MarketDataSnapshot(10);
@@ -689,7 +689,7 @@ public abstract class OrderBookBaseTest {
     public void shouldFullyMatchMarketableGtcOrderWithAllLiquidity() {
 
         // size=1000
-        OrderCommand cmd = OrderCommand.newOrder(GTC, 123, UID_2, 220000, MAX_PRICE, 1000, BID);
+        OrderCommand cmd = OrderCommand.newOrder(GTC, 123, UID_2, 220000, MAX_PRICE, 0L,1000, BID);
         processAndValidate(cmd, SUCCESS);
 
         L2MarketData snapshot = orderBook.getL2MarketDataSnapshot(10);
@@ -716,7 +716,7 @@ public abstract class OrderBookBaseTest {
     public void shouldMoveOrderFullyMatchAsMarketable() {
 
         // add new order and check it is there
-        OrderCommand cmd = OrderCommand.newOrder(GTC, 83, UID_2, 81200, MAX_PRICE, 20, BID);
+        OrderCommand cmd = OrderCommand.newOrder(GTC, 83, UID_2, 81200, MAX_PRICE, 0L,20, BID);
         processAndValidate(cmd, SUCCESS);
 
         List<MatcherTradeEvent> events = cmd.extractEvents();
@@ -742,7 +742,7 @@ public abstract class OrderBookBaseTest {
     @Test
     public void shouldMoveOrderFullyMatchAsMarketable2Prices() {
 
-        OrderCommand cmd = OrderCommand.newOrder(GTC, 83, UID_2, 81594, MAX_PRICE, 100, BID);
+        OrderCommand cmd = OrderCommand.newOrder(GTC, 83, UID_2, 81594, MAX_PRICE, 0L,100, BID);
         processAndValidate(cmd, SUCCESS);
 
         List<MatcherTradeEvent> events = cmd.extractEvents();
@@ -769,7 +769,7 @@ public abstract class OrderBookBaseTest {
     @Test
     public void shouldMoveOrderMatchesAllLiquidity() {
 
-        OrderCommand cmd = OrderCommand.newOrder(GTC, 83, UID_2, 81594, MAX_PRICE, 246, BID);
+        OrderCommand cmd = OrderCommand.newOrder(GTC, 83, UID_2, 81594, MAX_PRICE, 0L,246, BID);
         processAndValidate(cmd, SUCCESS);
 
         // move to marketable zone

--- a/src/test/java/exchange/core2/core/orderbook/OrderBookDirectImplTest.java
+++ b/src/test/java/exchange/core2/core/orderbook/OrderBookDirectImplTest.java
@@ -138,7 +138,7 @@ public abstract class OrderBookDirectImplTest extends OrderBookBaseTest {
 
         // placing limit bid orders
         for (long price = bottomPrice; price < INITIAL_PRICE; price++) {
-            OrderCommand cmd = OrderCommand.newOrder(GTC, orderId++, UID_1, price, price * 10, 1, BID);
+            OrderCommand cmd = OrderCommand.newOrder(GTC, orderId++, UID_1, price, price * 10, 0L,1, BID);
 //            log.debug("BID {}", price);
             processAndValidate(cmd, SUCCESS);
             results.put(price, -1L);
@@ -147,7 +147,7 @@ public abstract class OrderBookDirectImplTest extends OrderBookBaseTest {
 
         for (long price = topPrice; price >= bottomPrice; price--) {
             long size = price * price;
-            OrderCommand cmd = OrderCommand.newOrder(GTC, orderId++, UID_2, price, 0, size, ASK);
+            OrderCommand cmd = OrderCommand.newOrder(GTC, orderId++, UID_2, price, 0, 0L,size, ASK);
 //            log.debug("ASK {}", price);
             processAndValidate(cmd, SUCCESS);
             results.compute(price, (p, v) -> v == null ? size : v + size);
@@ -197,7 +197,7 @@ public abstract class OrderBookDirectImplTest extends OrderBookBaseTest {
 
         // placing limit ask orders
         for (long price = topPrice; price > INITIAL_PRICE; price--) {
-            OrderCommand cmd = OrderCommand.newOrder(GTC, orderId++, UID_1, price, 0, 1, ASK);
+            OrderCommand cmd = OrderCommand.newOrder(GTC, orderId++, UID_1, price, 0, 0L,1, ASK);
 //            log.debug("BID {}", price);
             processAndValidate(cmd, SUCCESS);
             results.put(price, -1L);
@@ -205,7 +205,7 @@ public abstract class OrderBookDirectImplTest extends OrderBookBaseTest {
 
         for (long price = bottomPrice; price <= topPrice; price++) {
             long size = price * price;
-            OrderCommand cmd = OrderCommand.newOrder(GTC, orderId++, UID_2, price, price * 10, size, BID);
+            OrderCommand cmd = OrderCommand.newOrder(GTC, orderId++, UID_2, price, price * 10, 0L,size, BID);
 //            log.debug("ASK {}", price);
             processAndValidate(cmd, SUCCESS);
             results.compute(price, (p, v) -> v == null ? size : v + size);

--- a/src/test/java/exchange/core2/tests/perf/modules/ITOrderBookBase.java
+++ b/src/test/java/exchange/core2/tests/perf/modules/ITOrderBookBase.java
@@ -56,14 +56,14 @@ public abstract class ITOrderBookBase {
 
         // match all asks
         long askSum = Arrays.stream(snapshot.askVolumes).sum();
-        IOrderBook.processCommand(orderBook, OrderCommand.newOrder(IOC, 100000000000L, -1, maxPrice, maxPrice, askSum, BID));
+        IOrderBook.processCommand(orderBook, OrderCommand.newOrder(IOC, 100000000000L, -1, maxPrice, maxPrice, 0L,askSum, BID));
 //        log.debug("{}", dumpOrderBook(orderBook.getL2MarketDataSnapshot(100000)));
 
         // match all bids
         long bidSum = Arrays.stream(snapshot.bidVolumes).sum();
 
 //        log.debug("Matching {} bids", bidSum);
-        IOrderBook.processCommand(orderBook, OrderCommand.newOrder(IOC, 100000000001L, -2, 1, 0, bidSum, ASK));
+        IOrderBook.processCommand(orderBook, OrderCommand.newOrder(IOC, 100000000001L, -2, 1, 0, 0L,bidSum, ASK));
 
 //        log.debug("{}", dumpOrderBook(orderBook.getL2MarketDataSnapshot(100000)));
 


### PR DESCRIPTION
**Integrated Stop Loss/Take Profit.**

_[NEED TO BE TESTED FIRST]_ - This is made for OrderBookNaiveImpl

It's not yet tested or performent but ready for improvements and the concept is there.

Used ConcurrentHashMap to store Bid/Ask orders for stop loss, since it's synchronized ... can be changed for a better and performent solution.

Collections.synchronizedList to stock range prices (rounded prices).

Why rounding prices?

The goal is to split the ConcurrentHashMap into various one depend on the rounded price, let's take an example better than thousen words:

If the stop price is: 1966$, it will be rounded by 50 which makes it: 2000 - The result will be a key in the ConcurrentHashMap and many new stopLoss orders within that range (1999, 1956, etc.) will be stored as an ArrayList into the value of that key.

Let's suppose we will get stop price: 2001, the new Key to store the stopLoss orders is: 2050 and all the one between 2050 - 2001 will be stored as list into this key.

50 is by default and can be changed as you wish to 100, 200, 500, 1000 etc.

The reason behind this, is to split the Map and quickly find the targetted pricing, it is also open for improvements, imagine you get +1M stop loss orders and be stored on one TreeMap? Each time iterating that big Map will slow down the matching engine, but this way it's fast by need to be studied well. This is a hard coded solution, but there is another way to do it in a separated micro service.


Cancel, Reduce, Move orders operations not yet implemented.

