### PR TITLE
MoveOrder (Update Timestamp)

### DIFF
--- a/src/main/java/exchange/core2/core/orderbook/OrderBookDirectImpl.java
+++ b/src/main/java/exchange/core2/core/orderbook/OrderBookDirectImpl.java
@@ -420,6 +420,9 @@ public final class OrderBookDirectImpl implements IOrderBook {
         // update price
         orderToMove.price = cmd.price;
 
+        // update timestamp
+        orderToMove.timestamp = cmd.timestamp;
+            
         // fill action fields (for events handling)
         cmd.action = orderToMove.getAction();
 


### PR DESCRIPTION
Timestamp must be updated when moving an order to a new price (Since other traders may already set an order at that new price and they have priority).