### PR TITLE
update installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Benchmark configuration:
 <dependency>
     <groupId>exchange.core2</groupId>
     <artifactId>exchange-core</artifactId>
-    <version>0.5.0</version>
+    <version>0.5.3</version>
 </dependency>
 ```
 


### PR DESCRIPTION
It seems that latest version is 0.5.3. README.md guide line should be fixed :)